### PR TITLE
Fix Ecosystem CI descriptor

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -16,7 +16,7 @@ env:
   # Repo specific setting #
   #########################
 
-  ECOSYSTEM_CI_REPO_PATH: quarkus-elasticsearch-reactive
+  ECOSYSTEM_CI_REPO_PATH: quarkiverse-elasticsearch-reactive
 
 jobs:
   build:


### PR DESCRIPTION
This fixes the generated descriptor to match the path used in https://github.com/quarkusio/quarkus-ecosystem-ci/tree/main/quarkiverse-elasticsearch-reactive